### PR TITLE
Fix Need Login Every Refresh

### DIFF
--- a/src/common/components/RouterGuard/index.tsx
+++ b/src/common/components/RouterGuard/index.tsx
@@ -12,8 +12,8 @@ const RouterGuard: React.FC = (props) => {
   const auth = useSelector((state: StoresState) => state.user.authenticated);
 
   useEffect(() => {
-    if (auth) setValid(true);
-    else setValid(false);
+    const user = localStorage.getItem('user');
+    auth || user ? setValid(true) : setValid(false);
   }, []);
 
   if (!valid) {


### PR DESCRIPTION
We need to log in every refresh since the user handling is not implement properly, so I add to check if there are any users in localstorage or not.

- Add check localstorage user at RouterGuard